### PR TITLE
Add Vitest tests and Japanese instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # codex
+
+このリポジトリには `nuxt3-app` ディレクトリに簡単な Nuxt3 アプリケーションが含まれています。
+
+## アプリの実行方法
+
+1. 依存関係をインストールします。
+   ```bash
+   cd nuxt3-app
+   npm install
+   ```
+2. 開発サーバーを起動します。
+   ```bash
+   npm run dev
+   ```
+   ブラウザで `http://localhost:3000` を開くとアプリが表示されます。
+
+## テストの実行方法
+
+以下のコマンドで Vitest を使用したテストを実行できます。
+
+```bash
+cd nuxt3-app
+npm test
+```

--- a/nuxt3-app/app.vue
+++ b/nuxt3-app/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/nuxt3-app/nuxt.config.ts
+++ b/nuxt3-app/nuxt.config.ts
@@ -1,0 +1,9 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  app: {
+    head: {
+      title: 'Nuxt3 App',
+    },
+  },
+})

--- a/nuxt3-app/package.json
+++ b/nuxt3-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nuxt3-app",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "node .output/server/index.mjs",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "nuxt": "^3.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/nuxt3-app/pages/index.vue
+++ b/nuxt3-app/pages/index.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Welcome to Nuxt3!</h1>
+    <p>This is a basic example page.</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+// You can add composition API logic here
+</script>

--- a/nuxt3-app/tests/basic.test.ts
+++ b/nuxt3-app/tests/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('math', () => {
+  it('adds numbers correctly', () => {
+    expect(1 + 1).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- Nuxt アプリに Vitest を導入し、サンプルテスト `basic.test.ts` を追加
- `package.json` にテストスクリプトと `vitest` の devDependency を設定
- README を日本語化し、テスト実行手順を追記

## Testing
- `npm test` *(fails: `vitest: not found`)*
